### PR TITLE
I just updated to latest versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ###############################
 # Build the FFmpeg-build image.
-FROM alpine:3.16.0 as build
+FROM alpine:3.21 as build
 
-ARG FFMPEG_VERSION=5.0
+ARG FFMPEG_VERSION=7.1
 
 ARG PREFIX=/opt/ffmpeg
 ARG LD_LIBRARY_PATH=/opt/ffmpeg/lib
@@ -82,7 +82,7 @@ RUN rm -rf /var/cache/apk/* /tmp/*
 
 ##########################
 # Build the release image.
-FROM alpine:3.16.0
+FROM alpine:3.21.0
 LABEL MAINTAINER Alfred Gutierrez <alf.g.jr@gmail.com>
 ENV PATH=/opt/ffmpeg/bin:$PATH
 


### PR DESCRIPTION
Alpine Linux 3.16.0 reached its end of life on May 23, 2024, and is no longer supported So I upgraded it to alpine:3.21.0
The latest stable release of FFmpeg is version 7.1